### PR TITLE
Simplify if/else

### DIFF
--- a/R/num-to-words.R
+++ b/R/num-to-words.R
@@ -140,11 +140,7 @@ small_int_to_words <- function(num) {
     }
 
   } else if (x[2] == '1') {
-    if (x[3] == '0') {
-      bits <- c(bits, "ten")
-    } else {
       bits <- c(bits, teens[[x[3]]])
-    }
   } else {
     bits <- c(bits, ones[[x[3]]])
   }


### PR DESCRIPTION
This is not necessary since `teens[[x[3]]]` is already equal to "ten" when `x[3] == "0"`. So we don't need to single out this case.

https://github.com/coolbutuseless/numberwang/blob/eb223ac83564318608cf487f8500af2223d8bab1/R/num-to-words.R#L29-L30

(I hope I didn't completely misunderstand the code but I think this is correct.)